### PR TITLE
Upgrade Gradle and Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip


### PR DESCRIPTION
One of my projects I'm currently working on relies on Gradle plugin v2.1.2 which is `classpath 'com.android.tools.build:gradle:2.1.2'`. So when I added the `binding-collection-adapter` library, somehow there was a clash with the binding adapter `android:afterTextChanged`. AS failed to compile and kept throwing following error:

```
> java.lang.RuntimeException: failure, see logs for details.
  cannot generate view binders java.util.NoSuchElementException
      at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1113)
      at java.util.TreeMap$KeyIterator.next(TreeMap.java:1169)
      at android.databinding.tool.store.SetterStore$1.compare(SetterStore.java:82)
      at android.databinding.tool.store.SetterStore$1.compare(SetterStore.java:60)
      at java.util.TimSort.countRunAndMakeAscending(TimSort.java:324)
      at java.util.TimSort.sort(TimSort.java:189)
      at java.util.TimSort.sort(TimSort.java:173)
      at java.util.Arrays.sort(Arrays.java:659)
      at java.util.Collections.sort(Collections.java:217)
      at android.databinding.tool.store.SetterStore.getMultiAttributeSetterCalls(SetterStore.java:473)
      at android.databinding.tool.BindingTarget.resolveMultiSetters(BindingTarget.java:203)
      at android.databinding.tool.LayoutBinder.<init>(LayoutBinder.java:238)
      at android.databinding.tool.DataBinder.<init>(DataBinder.java:52)
      at android.databinding.tool.CompilerChef.ensureDataBinder(CompilerChef.java:83)
      at android.databinding.tool.CompilerChef.sealModels(CompilerChef.java:168)
      at android.databinding.annotationprocessor.ProcessExpressions.writeResourceBundle(ProcessExpressions.java:149)
      at android.databinding.annotationprocessor.ProcessExpressions.onHandleStep(ProcessExpressions.java:82)
      at android.databinding.annotationprocessor.ProcessDataBinding$ProcessingStep.runStep(ProcessDataBinding.java:154)
      at android.databinding.annotationprocessor.ProcessDataBinding$ProcessingStep.access$000(ProcessDataBinding.java:139)
      at android.databinding.annotationprocessor.ProcessDataBinding.process(ProcessDataBinding.java:66)
      at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:793)
      at com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.java:722)
      at com.sun.tools.javac.processing.JavacProcessingEnvironment.access$1700(JavacProcessingEnvironment.java:97)
      at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1029)
      at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1163)
      at com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1108)
      at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:824)
      at com.sun.tools.javac.main.Main.compile(Main.java:439)
      at com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:132)
      at org.gradle.api.internal.tasks.compile.JdkJavaCompiler.execute(JdkJavaCompiler.java:46)
      at org.gradle.api.internal.tasks.compile.JdkJavaCompiler.execute(JdkJavaCompiler.java:33)
      at org.gradle.api.internal.tasks.compile.NormalizingJavaCompiler.delegateAndHandleErrors(NormalizingJavaCompiler.java:104)
      at org.gradle.api.internal.tasks.compile.NormalizingJavaCompiler.execute(NormalizingJavaCompiler.java:53)
      at org.gradle.api.internal.tasks.compile.NormalizingJavaCompiler.execute(NormalizingJavaCompiler.java:38)
      at org.gradle.api.internal.tasks.compile.CleaningJavaCompilerSupport.execute(CleaningJavaCompilerSupport.java:35)
      at org.gradle.api.internal.tasks.compile.CleaningJavaCompilerSupport.execute(CleaningJavaCompilerSupport.java:25)
      at org.gradle.api.tasks.compile.JavaCompile.performCompilation(JavaCompile.java:163)
      at org.gradle.api.tasks.compile.JavaCompile.compile(JavaCompile.java:145)
      at org.gradle.api.tasks.compile.JavaCompile.compile(JavaCompile.java:93)
      at com.android.build.gradle.tasks.factory.AndroidJavaCompile.compile(AndroidJavaCompile.java:49)
      at sun.reflect.GeneratedMethodAccessor413.invoke(Unknown Source)
      at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
      at java.lang.reflect.Method.invoke(Method.java:606)
```

So my assumption is that it might be because the discrepancy in Data Binding library versions between the 2 projects. After upgrading the Gradle plugin in the `binding-collection-adapter` library, the problem was gone. I also had to upgrade Gradle wrapper to the latest to get the library successfully compiled.