### PR TITLE
Fix for ViewPagerAdapter, getItemPosition calls equals instead of ==.

### DIFF
--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter/BindingViewPagerAdapter.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter/BindingViewPagerAdapter.java
@@ -125,7 +125,7 @@ public class BindingViewPagerAdapter<T> extends PagerAdapter implements BindingC
         T item = (T) ((View) object).getTag();
         if (items != null) {
             for (int i = 0; i < items.size(); i++) {
-                if (item == items.get(i)) {
+                if (item.equals(items.get(i))) {
                     return i;
                 }
             }


### PR DESCRIPTION
Hi, I've changed finding item position in ViewPagerAdater to work with objects having their equals overridden.