### PR TITLE
Added ability to use arbitrary ViewHolder

### DIFF
--- a/app/src/main/java/me/tatarka/bindingcollectionadapter/sample/LoggingRecyclerViewAdapter.java
+++ b/app/src/main/java/me/tatarka/bindingcollectionadapter/sample/LoggingRecyclerViewAdapter.java
@@ -6,13 +6,14 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
-import me.tatarka.bindingcollectionadapter.BindingRecyclerViewAdapter;
+
+import me.tatarka.bindingcollectionadapter.DefaultBindingRecyclerViewAdapter;
 import me.tatarka.bindingcollectionadapter.ItemViewArg;
 
 /**
  * Created by evan on 6/30/15.
  */
-public class LoggingRecyclerViewAdapter<T> extends BindingRecyclerViewAdapter<T> {
+public class LoggingRecyclerViewAdapter<T> extends DefaultBindingRecyclerViewAdapter<T> {
     public static final String TAG = "RecyclerView";
 
     public LoggingRecyclerViewAdapter(@NonNull ItemViewArg<T> arg) {

--- a/bindingcollectionadapter-recyclerview/src/androidTest/java/me/tatarka/bindingcollectionadapter/recyclerview/RecyclerViewInflationTest.java
+++ b/bindingcollectionadapter-recyclerview/src/androidTest/java/me/tatarka/bindingcollectionadapter/recyclerview/RecyclerViewInflationTest.java
@@ -46,7 +46,7 @@ public class RecyclerViewInflationTest {
 
         RecyclerView recyclerView = (RecyclerView) binding.getRoot();
         @SuppressWarnings("unchecked")
-        BindingRecyclerViewAdapter<String> adapter = (BindingRecyclerViewAdapter<String>) recyclerView.getAdapter();
+        BindingRecyclerViewAdapter<String, ?> adapter = (BindingRecyclerViewAdapter<String, ?>) recyclerView.getAdapter();
 
         assertThat(TestHelpers.iterable(adapter)).containsExactlyElementsOf(items);
     }
@@ -62,7 +62,7 @@ public class RecyclerViewInflationTest {
 
         RecyclerView recyclerView = (RecyclerView) binding.getRoot();
         @SuppressWarnings("unchecked")
-        BindingRecyclerViewAdapter<String> adapter = (BindingRecyclerViewAdapter<String>) recyclerView.getAdapter();
+        BindingRecyclerViewAdapter<String, ?> adapter = (BindingRecyclerViewAdapter<String, ?>) recyclerView.getAdapter();
 
         assertThat(adapter).isInstanceOf(TestHelpers.MyBindingRecyclerViewAdapter.class);
     }

--- a/bindingcollectionadapter-recyclerview/src/androidTest/java/me/tatarka/bindingcollectionadapter/recyclerview/TestHelpers.java
+++ b/bindingcollectionadapter-recyclerview/src/androidTest/java/me/tatarka/bindingcollectionadapter/recyclerview/TestHelpers.java
@@ -11,6 +11,8 @@ import java.util.List;
 import me.tatarka.bindingcollectionadapter.BaseItemViewSelector;
 import me.tatarka.bindingcollectionadapter.BindingListViewAdapter;
 import me.tatarka.bindingcollectionadapter.BindingRecyclerViewAdapter;
+import me.tatarka.bindingcollectionadapter.BindingViewHolder;
+import me.tatarka.bindingcollectionadapter.DefaultBindingRecyclerViewAdapter;
 import me.tatarka.bindingcollectionadapter.ItemView;
 import me.tatarka.bindingcollectionadapter.ItemViewArg;
 import me.tatarka.bindingcollectionadapter.ItemViewSelector;
@@ -56,18 +58,21 @@ public class TestHelpers {
 
     public static final BindingRecyclerViewAdapterFactory MY_RECYCLER_VIEW_ADAPTER_FACTORY = new BindingRecyclerViewAdapterFactory() {
         @Override
-        public <T> BindingRecyclerViewAdapter<T> create(RecyclerView recyclerView, ItemViewArg<T> arg) {
-            return new MyBindingRecyclerViewAdapter<>(arg);
+        public <T, VH extends RecyclerView.ViewHolder & BindingViewHolder>
+        BindingRecyclerViewAdapter<T, VH>
+        create(RecyclerView recyclerView, ItemViewArg<T> arg) {
+            return new MyBindingRecyclerViewAdapter(arg);
         }
     };
 
-    public static class MyBindingRecyclerViewAdapter<T> extends BindingRecyclerViewAdapter<T> {
+    public static class MyBindingRecyclerViewAdapter<T> extends DefaultBindingRecyclerViewAdapter<T> {
         public MyBindingRecyclerViewAdapter(@NonNull ItemViewArg<T> arg) {
             super(arg);
         }
     }
 
-    public static <T> Iterable<T> iterable(final BindingRecyclerViewAdapter<T> adapter) {
+    public static <T, VH extends RecyclerView.ViewHolder & BindingViewHolder>
+    Iterable<T> iterable(final BindingRecyclerViewAdapter<T, VH> adapter) {
         if (adapter == null) return null;
         return new IndexIterable<>(new Factory<IndexIterator<T>>() {
             @Override

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/BindingRecyclerViewAdapters.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/BindingRecyclerViewAdapters.java
@@ -15,14 +15,16 @@ public class BindingRecyclerViewAdapters {
     // RecyclerView
     @SuppressWarnings("unchecked")
     @BindingAdapter(value = {"itemView", "items", "adapter", "itemIds"}, requireAll = false)
-    public static <T> void setAdapter(RecyclerView recyclerView, ItemViewArg<T> arg, List<T> items, BindingRecyclerViewAdapterFactory factory, BindingRecyclerViewAdapter.ItemIds<T> itemIds) {
+    public static <T, VH extends RecyclerView.ViewHolder & BindingViewHolder>
+    void setAdapter(RecyclerView recyclerView, ItemViewArg<T> arg, List<T> items, BindingRecyclerViewAdapterFactory factory, BindingRecyclerViewAdapter.ItemIds<T> itemIds) {
         if (arg == null) {
             throw new IllegalArgumentException("itemView must not be null");
         }
         if (factory == null) {
             factory = BindingRecyclerViewAdapterFactory.DEFAULT;
         }
-        BindingRecyclerViewAdapter<T> adapter = (BindingRecyclerViewAdapter<T>) recyclerView.getAdapter();
+        BindingRecyclerViewAdapter<T, VH> adapter
+                = (BindingRecyclerViewAdapter<T, VH>) recyclerView.getAdapter();
         if (adapter == null) {
             adapter = factory.create(recyclerView, arg);
             adapter.setItems(items);
@@ -42,7 +44,8 @@ public class BindingRecyclerViewAdapters {
     public static BindingRecyclerViewAdapterFactory toRecyclerViewAdapterFactory(final String className) {
         return new BindingRecyclerViewAdapterFactory() {
             @Override
-            public <T> BindingRecyclerViewAdapter<T> create(RecyclerView recyclerView, ItemViewArg<T> arg) {
+            public <T, VH extends RecyclerView.ViewHolder & BindingViewHolder>
+            BindingRecyclerViewAdapter<T, VH> create(RecyclerView recyclerView, ItemViewArg<T> arg) {
                 return Utils.createClass(className, arg);
             }
         };

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/BindingViewHolder.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/BindingViewHolder.java
@@ -1,0 +1,7 @@
+package me.tatarka.bindingcollectionadapter;
+
+import android.databinding.ViewDataBinding;
+
+public interface BindingViewHolder {
+    ViewDataBinding getBinding();
+}

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/DefaultBindingRecyclerViewAdapter.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/DefaultBindingRecyclerViewAdapter.java
@@ -1,0 +1,16 @@
+package me.tatarka.bindingcollectionadapter;
+
+import android.databinding.ViewDataBinding;
+import android.support.annotation.NonNull;
+
+public class DefaultBindingRecyclerViewAdapter<T> extends BindingRecyclerViewAdapter<T, DefaultBindingViewHolder> {
+
+    public DefaultBindingRecyclerViewAdapter(@NonNull ItemViewArg<T> arg) {
+        super(arg);
+    }
+
+    @Override
+    protected DefaultBindingViewHolder createViewHolder(ViewDataBinding binding) {
+        return new DefaultBindingViewHolder(binding);
+    }
+}

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/DefaultBindingViewHolder.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/DefaultBindingViewHolder.java
@@ -1,0 +1,19 @@
+package me.tatarka.bindingcollectionadapter;
+
+import android.databinding.ViewDataBinding;
+import android.support.v7.widget.RecyclerView;
+
+public class DefaultBindingViewHolder extends RecyclerView.ViewHolder implements BindingViewHolder {
+
+    private final ViewDataBinding binding;
+
+    public DefaultBindingViewHolder(ViewDataBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+
+    @Override
+    public ViewDataBinding getBinding() {
+        return binding;
+    }
+}

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/factories/BindingRecyclerViewAdapterFactory.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter/factories/BindingRecyclerViewAdapterFactory.java
@@ -1,17 +1,27 @@
 package me.tatarka.bindingcollectionadapter.factories;
 
+import android.databinding.ViewDataBinding;
 import android.support.v7.widget.RecyclerView;
 
 import me.tatarka.bindingcollectionadapter.BindingRecyclerViewAdapter;
+import me.tatarka.bindingcollectionadapter.BindingViewHolder;
+import me.tatarka.bindingcollectionadapter.DefaultBindingViewHolder;
 import me.tatarka.bindingcollectionadapter.ItemViewArg;
 
 public interface BindingRecyclerViewAdapterFactory {
-    <T> BindingRecyclerViewAdapter<T> create(RecyclerView recyclerView, ItemViewArg<T> arg);
+    <T, VH extends RecyclerView.ViewHolder & BindingViewHolder>
+    BindingRecyclerViewAdapter<T, VH> create(RecyclerView recyclerView, ItemViewArg<T> arg);
 
     BindingRecyclerViewAdapterFactory DEFAULT = new BindingRecyclerViewAdapterFactory() {
         @Override
-        public <T> BindingRecyclerViewAdapter<T> create(RecyclerView recyclerView, ItemViewArg<T> arg) {
-            return new BindingRecyclerViewAdapter<>(arg);
+        public <T, VH extends RecyclerView.ViewHolder & BindingViewHolder> BindingRecyclerViewAdapter<T, VH>
+        create(RecyclerView recyclerView, ItemViewArg<T> arg) {
+            return new BindingRecyclerViewAdapter(arg) {
+                @Override
+                protected RecyclerView.ViewHolder createViewHolder(ViewDataBinding binding) {
+                    return new DefaultBindingViewHolder(binding);
+                }
+            };
         }
     };
 }


### PR DESCRIPTION
`BindingRecyclerViewAdapter` made abstract with a second generic type parameter for the view holder. Useful when you are forced to use a specific base view holder (in example 3rd party libraries like [bignerdranch/recyclerview-multiselect](https://www.google.bg/url?sa=t&rct=j&q=&esrc=s&source=web&cd=13&cad=rja&uact=8&ved=0ahUKEwj34YnZp5bOAhVLfxoKHSYlDawQFghHMAw&url=https%3A%2F%2Fgithub.com%2Fbignerdranch%2Frecyclerview-multiselect&usg=AFQjCNE22djmeq4NTLCFQngR_Xf8bT73WQ&sig2=yl3GSYMjR1jdEoFp1QQJvA) requires you to subclass their base view holder.
- A custom view holder only needs to implement the `BindingViewHolder` interface.
- There is a `DefaultBindingViewHolder` ready to use when no custom view holder is required. 
- For simple migration just replace `BindingRecyclerViewAdapter` with `**Default**BindingRecyclerViewAdapter`.

I know the generic signature is very long and ugly, so I if you come up with a cleaner solution, just ignore this.

Related issue:
#48 Enhancement suggestion: allow usage of custom ViewHolder implementation