### PR TITLE
remove same items check

### DIFF
--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
@@ -45,9 +45,6 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
 
     @Override
     public void setItems(@Nullable List<T> items) {
-        if (this.items == items) {
-            return;
-        }
         // If a recyclerview is listening, set up listeners. Otherwise wait until one is attached.
         // No need to make a sound if nobody is listening right?
         if (recyclerView != null) {


### PR DESCRIPTION
Hi, I have removed "this.items = items" in setItems() method, because when I use databinding in recycler view, I have a List<T> list1, and if I modify this list1 directly, setItems() will compare "this.items = items" therefore it will return. I understand you want to make this efficient, so you have put this line, but I am thinking maybe its better remove this.