### PR TITLE
Unregister unnecessary callbacks attached to weakly reached adapters

### DIFF
--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/AdapterReference.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/AdapterReference.java
@@ -1,0 +1,60 @@
+package me.tatarka.bindingcollectionadapter2;
+
+import android.databinding.ObservableList;
+import android.support.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+/**
+ * A weak reference for {@link BindingCollectionAdapter}.
+ *
+ * @param <A> the adapter type
+ * @param <T> the item type
+ */
+final class AdapterReference<A extends BindingCollectionAdapter<T>, T> extends WeakReference<A> {
+    private final ObservableList.OnListChangedCallback<? extends ObservableList<T>> callback;
+    @Nullable
+    private ObservableList<T> items;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param adapter  the adapter
+     * @param queue    the reference queue
+     * @param callback the callback to be registered into the adapter's item
+     */
+    AdapterReference(A adapter, AdapterReferenceQueue queue, ObservableList.OnListChangedCallback<? extends ObservableList<T>> callback) {
+        super(adapter, queue);
+        this.callback = callback;
+    }
+
+    @Override
+    public A get() {
+        A adapter = super.get();
+        if (adapter == null) {
+            unregisterCallback();
+        }
+        return adapter;
+    }
+
+    /**
+     * Sets the adapter's items.
+     *
+     * @param items the items held by the adapter
+     */
+    void setItems(@Nullable List<T> items) {
+        this.items = items instanceof ObservableList ? (ObservableList<T>) items : null;
+    }
+
+    /**
+     * Unregisters the callback instance from the adapter's items.
+     */
+    void unregisterCallback() {
+        ObservableList<T> items = this.items;
+        if (items != null) {
+            this.items = null;
+            items.removeOnListChangedCallback(callback);
+        }
+    }
+}

--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/AdapterReferenceQueue.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/AdapterReferenceQueue.java
@@ -1,0 +1,21 @@
+package me.tatarka.bindingcollectionadapter2;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+
+/**
+ * A reference queue for {@link AdapterReference}.
+ */
+final class AdapterReferenceQueue extends ReferenceQueue<BindingCollectionAdapter<?>> {
+    /**
+     * Removes {@link android.databinding.ObservableList.OnListChangedCallback} instances no longer
+     * needed.
+     */
+    void expungeStaleCallbacks() {
+        for (Reference<?> ref; (ref = poll()) != null; ) {
+            if (ref instanceof AdapterReference) {
+                ((AdapterReference<?, ?>) ref).unregisterCallback();
+            }
+        }
+    }
+}

--- a/bindingcollectionadapter/src/test/java/me/tatarka/bindingcollectionadapter2/AdapterReferenceQueueTest.java
+++ b/bindingcollectionadapter/src/test/java/me/tatarka/bindingcollectionadapter2/AdapterReferenceQueueTest.java
@@ -1,0 +1,36 @@
+package me.tatarka.bindingcollectionadapter2;
+
+import android.databinding.ObservableList;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AdapterReferenceQueueTest {
+    @Mock
+    private ObservableList.OnListChangedCallback<ObservableList<Object>> callback;
+    @Mock
+    private ObservableList<Object> items;
+
+    @SuppressWarnings("UnusedAssignment")
+    @Test
+    public void expungeStaleCallbacks() throws Exception {
+        AdapterReferenceQueue queue = new AdapterReferenceQueue();
+        BindingCollectionAdapter<Object> adapter = new BindingViewPagerAdapter<>();
+        AdapterReference<BindingCollectionAdapter<Object>, Object> ref = new AdapterReference<>(adapter, queue, callback);
+        ref.setItems(items);
+
+        adapter = null;
+        System.gc();
+        do {
+            Thread.sleep(50);
+        } while (ref.get() != null);
+        queue.expungeStaleCallbacks();
+
+        verify(items).removeOnListChangedCallback(callback);
+    }
+}


### PR DESCRIPTION
Using android.arch.lifecycle.ViewModel, callbacks that are not explicitly unregistered will continue to be kept in the ObservableList even if the Activity is discarded due to screen rotation.
This is because the ViewModels are managed by the retained fragment.
In order to avoid this, monitor the ReferenceQueue and unregister callbacks attached to weakly reached adapters.
