### PR TITLE
Use Gradle plugin 3.1.0-alpha6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha06'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     }


### PR DESCRIPTION
Use Gradle plugin 3.1.0-alpha6 to be compatible with the new changes (databinding v2 and LiveData support). You need to recompile with this gradle plugin version, otherwise people won't be able to use your library when they build with this version. It leads to bad serialVersionUIDs and missing databinding generated classes).