### PR TITLE
Fixes potential NPE when items are in LiveData

### DIFF
--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
@@ -108,7 +108,9 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
 
     @Override
     public void onBindBinding(@NonNull ViewDataBinding binding, int variableId, @LayoutRes int layoutRes, int position, T item) {
-        if (itemBinding.bind(binding, item)) {
+        boolean bound = itemBinding.bind(binding, item);
+        binding.setLifecycleOwner(lifecycleOwner);
+        if (bound) {
             binding.executePendingBindings();
         }
     }
@@ -195,8 +197,6 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
         if (isForDataBinding(payloads)) {
             binding.executePendingBindings();
         } else {
-            binding.setLifecycleOwner(lifecycleOwner);
-
             T item = items.get(position);
             onBindBinding(binding, itemBinding.variableId(), itemBinding.layoutRes(), position, item);
         }


### PR DESCRIPTION
Currently, if you use a @BindingAdapter that requires a non-null argument and observe a list of items from LiveData you'll get an NPE since calling setLifecycleOwner leads to a @BindingAdapter invocation. Setting a lifecycle owner after binding an item fixes the issue.