### PR TITLE
ItemBinding can be contravariant in adapters

### DIFF
--- a/bindingcollectionadapter-paging/src/main/java/me/tatarka/bindingcollectionadapter2/PagedBindingRecyclerViewAdapters.java
+++ b/bindingcollectionadapter-paging/src/main/java/me/tatarka/bindingcollectionadapter2/PagedBindingRecyclerViewAdapters.java
@@ -15,7 +15,7 @@ public class PagedBindingRecyclerViewAdapters {
     @SuppressWarnings("unchecked")
     @BindingAdapter(value = {"itemBinding", "items", "adapter", "itemIds", "viewHolder", "diffConfig"}, requireAll = false)
     public static <T> void setAdapter(RecyclerView recyclerView,
-                                      ItemBinding<T> itemBinding,
+                                      ItemBinding<? super T> itemBinding,
                                       PagedList<T> items,
                                       BindingRecyclerViewAdapter<T> adapter,
                                       BindingRecyclerViewAdapter.ItemIds<? super T> itemIds,

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
@@ -29,7 +29,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHolder> implements BindingCollectionAdapter<T> {
     private static final Object DATA_INVALIDATION = new Object();
 
-    private ItemBinding<T> itemBinding;
+    private ItemBinding<? super T> itemBinding;
     private WeakReferenceOnListChangedCallback<T> callback;
     private List<T> items;
     private LayoutInflater inflater;
@@ -44,7 +44,7 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
     private LifecycleOwner lifecycleOwner;
 
     @Override
-    public void setItemBinding(@NonNull ItemBinding<T> itemBinding) {
+    public void setItemBinding(@NonNull ItemBinding<? super T> itemBinding) {
         this.itemBinding = itemBinding;
     }
 
@@ -68,7 +68,7 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
 
     @NonNull
     @Override
-    public ItemBinding<T> getItemBinding() {
+    public ItemBinding<? super T> getItemBinding() {
         if (itemBinding == null) {
             throw new NullPointerException("itemBinding == null");
         }

--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapters.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapters.java
@@ -18,7 +18,7 @@ public class BindingRecyclerViewAdapters {
     @SuppressWarnings("unchecked")
     @BindingAdapter(value = {"itemBinding", "items", "adapter", "itemIds", "viewHolder", "diffConfig"}, requireAll = false)
     public static <T> void setAdapter(RecyclerView recyclerView,
-                                      ItemBinding<T> itemBinding,
+                                      ItemBinding<? super T> itemBinding,
                                       List<T> items,
                                       BindingRecyclerViewAdapter<T> adapter,
                                       BindingRecyclerViewAdapter.ItemIds<? super T> itemIds,

--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingCollectionAdapter.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingCollectionAdapter.java
@@ -22,7 +22,7 @@ public interface BindingCollectionAdapter<T> {
     /**
      * Sets the item biding for the adapter.
      */
-    void setItemBinding(@NonNull ItemBinding<T> itemBinding);
+    void setItemBinding(@NonNull ItemBinding<? super T> itemBinding);
 
     /**
      * Returns the {@link ItemBinding} that the adapter that was set.
@@ -30,7 +30,7 @@ public interface BindingCollectionAdapter<T> {
      * @throws NullPointerException if the item binding was not set.
      */
     @NonNull
-    ItemBinding<T> getItemBinding();
+    ItemBinding<? super T> getItemBinding();
 
     /**
      * Sets the adapter's items. These items will be displayed based on the {@link ItemBinding}. If

--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingCollectionAdapters.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingCollectionAdapters.java
@@ -9,8 +9,6 @@ import java.util.List;
 import androidx.annotation.LayoutRes;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.BindingConversion;
-import androidx.databinding.DataBindingUtil;
-import androidx.databinding.ViewDataBinding;
 import androidx.viewpager.widget.ViewPager;
 
 /**
@@ -20,7 +18,7 @@ public class BindingCollectionAdapters {
     // AdapterView
     @SuppressWarnings("unchecked")
     @BindingAdapter(value = {"itemBinding", "itemTypeCount", "items", "adapter", "itemDropDownLayout", "itemIds", "itemIsEnabled"}, requireAll = false)
-    public static <T> void setAdapter(AdapterView adapterView, ItemBinding<T> itemBinding, Integer itemTypeCount, List items, BindingListViewAdapter<T> adapter, @LayoutRes int itemDropDownLayout, BindingListViewAdapter.ItemIds<? super T> itemIds, BindingListViewAdapter.ItemIsEnabled<? super T> itemIsEnabled) {
+    public static <T> void setAdapter(AdapterView adapterView, ItemBinding<? super T> itemBinding, Integer itemTypeCount, List items, BindingListViewAdapter<T> adapter, @LayoutRes int itemDropDownLayout, BindingListViewAdapter.ItemIds<? super T> itemIds, BindingListViewAdapter.ItemIsEnabled<? super T> itemIsEnabled) {
         if (itemBinding == null) {
             throw new IllegalArgumentException("onItemBind must not be null");
         }
@@ -57,7 +55,7 @@ public class BindingCollectionAdapters {
     // ViewPager
     @SuppressWarnings("unchecked")
     @BindingAdapter(value = {"itemBinding", "items", "adapter", "pageTitles"}, requireAll = false)
-    public static <T> void setAdapter(ViewPager viewPager, ItemBinding<T> itemBinding, List items, BindingViewPagerAdapter<T> adapter, BindingViewPagerAdapter.PageTitles<T> pageTitles) {
+    public static <T> void setAdapter(ViewPager viewPager, ItemBinding<? super T> itemBinding, List items, BindingViewPagerAdapter<T> adapter, BindingViewPagerAdapter.PageTitles<T> pageTitles) {
         if (itemBinding == null) {
             throw new IllegalArgumentException("onItemBind must not be null");
         }

--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingListViewAdapter.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingListViewAdapter.java
@@ -23,7 +23,7 @@ import androidx.lifecycle.LifecycleOwner;
  */
 public class BindingListViewAdapter<T> extends BaseAdapter implements BindingCollectionAdapter<T> {
     private final int itemTypeCount;
-    private ItemBinding<T> itemBinding;
+    private ItemBinding<? super T> itemBinding;
     @LayoutRes
     private int dropDownItemLayout;
     private WeakReferenceOnListChangedCallback<T> callback;
@@ -45,7 +45,7 @@ public class BindingListViewAdapter<T> extends BaseAdapter implements BindingCol
     }
 
     @Override
-    public void setItemBinding(@NonNull ItemBinding<T> itemBinding) {
+    public void setItemBinding(@NonNull ItemBinding<? super T> itemBinding) {
         this.itemBinding = itemBinding;
     }
 
@@ -61,7 +61,7 @@ public class BindingListViewAdapter<T> extends BaseAdapter implements BindingCol
 
     @NonNull
     @Override
-    public ItemBinding<T> getItemBinding() {
+    public ItemBinding<? super T> getItemBinding() {
         if (itemBinding == null) {
             throw new NullPointerException("itemBinding == null");
         }

--- a/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingViewPagerAdapter.java
+++ b/bindingcollectionadapter/src/main/java/me/tatarka/bindingcollectionadapter2/BindingViewPagerAdapter.java
@@ -24,7 +24,7 @@ import androidx.viewpager.widget.PagerAdapter;
  * changes to that list.
  */
 public class BindingViewPagerAdapter<T> extends PagerAdapter implements BindingCollectionAdapter<T> {
-    private ItemBinding<T> itemBinding;
+    private ItemBinding<? super T> itemBinding;
     private WeakReferenceOnListChangedCallback<T> callback;
     private List<T> items;
     private LayoutInflater inflater;
@@ -35,7 +35,7 @@ public class BindingViewPagerAdapter<T> extends PagerAdapter implements BindingC
     private List<View> views = new ArrayList<>();
 
     @Override
-    public void setItemBinding(@NonNull ItemBinding<T> itemBinding) {
+    public void setItemBinding(@NonNull ItemBinding<? super T> itemBinding) {
         this.itemBinding = itemBinding;
     }
 
@@ -56,7 +56,7 @@ public class BindingViewPagerAdapter<T> extends PagerAdapter implements BindingC
 
     @NonNull
     @Override
-    public ItemBinding<T> getItemBinding() {
+    public ItemBinding<? super T> getItemBinding() {
         if (itemBinding == null) {
             throw new NullPointerException("itemBinding == null");
         }


### PR DESCRIPTION
ItemBinding is used to map items of type T to their layout and binding variable, among others. It might well be the case that the ItemBinding that is passed to the adapters can not only map instances of type T, but any instances of some supertype of T, as well as T itself. This relaxation is in fact already made for the `ItemIds` callback.

This nominally changes the public API, but since `ItemBinding<T>` is a sub-type of `ItemBinding<? super T>`, most existing code should work as-is (e.g. the tests compiled and passed without any modifications). Only exception AFAIK is if someone has derived `BindingCollectionAdapter`, or one of its implementations, and overridden `get`/`setItemBinding`. They would need to change the method signatures to match to avoid compilation error.