### PR TITLE
Changed to use JUnit exception handling feature

### DIFF
--- a/bindingcollectionadapter/src/test/java/me/tatarka/bindingcollectionadapter2/OnItemBindClassTest.java
+++ b/bindingcollectionadapter/src/test/java/me/tatarka/bindingcollectionadapter2/OnItemBindClassTest.java
@@ -10,12 +10,13 @@ import java.util.List;
 import me.tatarka.bindingcollectionadapter2.itembindings.OnItemBindClass;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 
 @RunWith(JUnit4.class)
 public class OnItemBindClassTest {
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void selectsBasedOnClass() {
         OnItemBindClass<Object> onItemBind = new OnItemBindClass<>()
                 .map(String.class, 0, 1)
@@ -31,13 +32,7 @@ public class OnItemBindClassTest {
 
         assertThat(itemBinding.variableId()).isEqualTo(2);
         assertThat(itemBinding.layoutRes()).isEqualTo(3);
-
-        try {
-            itemBinding.onItemBind(3, new Object());
-            fail();
-        } catch (IllegalArgumentException e) {
-            // pass
-        }
+        itemBinding.onItemBind(3, new Object());
     }
 
     @Test


### PR DESCRIPTION
Improved exception handling in the test suite. The previous code is considered a test smell. 
The idea is giving preference to JUnit’s exception handling feature to automatically pass/fail the test instead of custom exception handling code or exception throwing.
