### PR TITLE
Mechanism for overriding notification behavior

### DIFF
--- a/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
+++ b/bindingcollectionadapter-recyclerview/src/main/java/me/tatarka/bindingcollectionadapter2/BindingRecyclerViewAdapter.java
@@ -103,7 +103,7 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
             }
         }
         this.items = items;
-        notifyDataSetChanged();
+        onDistinctItems(items);
     }
 
     @Override
@@ -189,6 +189,14 @@ public class BindingRecyclerViewAdapter<T> extends RecyclerView.Adapter<ViewHold
         } else {
             return new BindingViewHolder(binding);
         }
+    }
+
+    /**
+     * Allows an overridden notification behavior when distinct items are set such as when the items
+     * are set for the first time.
+     */
+    protected void onDistinctItems(@Nullable List<T> items) {
+        notifyDataSetChanged();
     }
 
     private static class BindingViewHolder extends ViewHolder {


### PR DESCRIPTION
`onDistinctItems` is called when the adapter receives new (distinct from
 previous) `items`. This allows for changing the notification behavior
 in a backward-compatible way e.g. from `notifyDataSetChanged() to
 `notifyItemRangeInserted()`.

Our app uses a custom `ItemAnimator` for insertions and with this change, we're able to call `notifyItemRangeInserted` when the adapter initially receives items and there by trigger an insert animation as can be observed in this clip:

https://user-images.githubusercontent.com/14194998/116545693-033f5900-a8f1-11eb-9de5-df6c71cc59ed.mov

The current behavior is that `notifyDataSetChanged()` is called which for the first item will _not_ trigger an insert animation. See clip for difference and notice the first item:


https://user-images.githubusercontent.com/14194998/116545869-3c77c900-a8f1-11eb-9412-8f3e7135ef58.mov

